### PR TITLE
Add GH action for pkgdown build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,3 +6,6 @@ _pkgdown.yml
 ^\.Rproj\.user$
 ^\.github$
 ^codecov\.yml$
+^_pkgdown\.yml$
+^docs$
+^pkgdown$

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -31,13 +31,27 @@ jobs:
         with:
           use-public-rspm: true
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y grass-dev libgdal-dev libudunits2-dev libharfbuzz-dev libfribidi-dev
+  
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::pkgdown, local::.
           needs: website
 
+      - name: Download test dataset
+        run: |
+          wget https://grass.osgeo.org/sampledata/north_carolina/nc_basic_spm_grass7.zip -O /tmp/nc_basic_spm_grass7.zip
+          unzip /tmp/nc_basic_spm_grass7.zip -d /tmp/grassdb
+          rm /tmp/nc_basic_spm_grass7.zip  
+
       - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, run_dont_run = TRUE)
+        run: |
+          gisBase <- system2("grass", "--config path", stdout = TRUE)
+          loc <- rgrass::initGRASS(gisBase = gisBase, gisDbase = "/tmp/grassdb", location = "nc_basic_spm_grass7", mapset = "PERMANENT", override = TRUE)
+          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, run_dont_run = TRUE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Build site
         run: |
           gisBase <- system2("grass", "--config path", stdout = TRUE)
-          loc <- rgrass::initGRASS(gisBase = gisBase, gisDbase = "/tmp/grassdb", location = "nc_basic_spm_grass7", mapset = "PERMANENT", override = TRUE)
+          rgrass::initGRASS(gisBase = gisBase, gisDbase = "/tmp/grassdb", location = "nc_basic_spm_grass7", mapset = "PERMANENT")
           pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, run_dont_run = TRUE)
         shell: Rscript {0}
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,0 +1,49 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+name: pkgdown.yaml
+
+permissions: read-all
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    # Only restrict concurrency for non-PR jobs
+    concurrency:
+      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - name: Build site
+        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, run_dont_run = TRUE)
+        shell: Rscript {0}
+
+      - name: Deploy to GitHub pages 🚀
+        if: github.event_name != 'pull_request'
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        with:
+          clean: false
+          branch: gh-pages
+          folder: docs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .httr-oauth
 .DS_Store
 *.Rproj
+docs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+url: https://osgeo.github.io/rgrass/
 template:
   bootstrap: 5
-url: https://osgeo.github.io/rgrass/
+


### PR DESCRIPTION
## Purpose

Added the GH action for building the `rgrass` documentation website. This publishes the `docs` folder to a `gh_pages` branch upon changes to `main`. The pkgdown site is built using the same process as previously performed manually, i.e., using `pkgdown::build_site(run_dont_run = TRUE)` argument to run the examples that are enclosed in `\dontrun{}`.