### PR TITLE
Updated pkgdown GH action to run all examples

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -14,13 +14,13 @@ permissions: read-all
 
 jobs:
   pkgdown:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     # Only restrict concurrency for non-PR jobs
     concurrency:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      GRASS_INSTALLATION: /usr/lib/grass83 
+      GRASS_INSTALLATION: /usr/lib/grass78
     permissions:
       contents: write
     steps:
@@ -35,7 +35,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y grass-dev libgdal-dev libudunits2-dev libharfbuzz-dev libfribidi-dev
+          sudo apt-get install -y grass libgdal-dev libudunits2-dev libharfbuzz-dev libfribidi-dev
   
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -48,12 +48,9 @@ jobs:
           unzip /tmp/nc_basic_spm_grass7.zip -d /tmp/grassdb
           rm /tmp/nc_basic_spm_grass7.zip  
 
-      - name: Build site
+      - name: Build pkgdown site
         run: |
-          gisBase <- system2("grass", "--config path", stdout = TRUE)
-          rgrass::initGRASS(gisBase = gisBase, gisDbase = "/tmp/grassdb", location = "nc_basic_spm_grass7", mapset = "PERMANENT")
-          pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, run_dont_run = TRUE)
-        shell: Rscript {0}
+          grass /tmp/grassdb/nc_basic_spm_grass7/PERMANENT --exec sh -c "R -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE, run_dont_run = TRUE)'"
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'

--- a/R/initGRASS.R
+++ b/R/initGRASS.R
@@ -110,6 +110,11 @@
 #'   plot(r, col = terrain.colors(50))
 #' }
 #'
+#' # Check for existing GRASS session running
+#' if (run) {
+#'   loc_existing <- try(gmeta())
+#' }
+#'
 #' if (run) {
 #'   # Initialize a temporary GRASS project using the example data
 #'   loc <- initGRASS(
@@ -141,6 +146,19 @@
 #'   # Read the results back into R and plot
 #'   u1 <- read_RAST(c("elev", "slope", "aspect"), return_format = "terra")
 #'   plot(u1[["elev"]], col = terrain.colors(50))
+#' }
+#'
+#' # Restore the original GRASS session
+#' if (run) {
+#'   if (!inherits(loc, "try-error")) {
+#'     loc <- initGRASS(
+#'       gisBase = GRASS_INSTALLATION,
+#'       gisDbase = loc_existing$GISDBASE,
+#'       location = loc_existing$LOCATION_NAME,
+#'       mapset = loc_existing$MAPSET,
+#'       override = TRUE
+#'     )
+#'   }
 #' }
 initGRASS <- function(
     gisBase = NULL, home, SG, gisDbase, addon_base, location,

--- a/man/initGRASS.Rd
+++ b/man/initGRASS.Rd
@@ -145,6 +145,11 @@ if (run) {
   plot(r, col = terrain.colors(50))
 }
 
+# Check for existing GRASS session running
+if (run) {
+  loc_existing <- try(gmeta())
+}
+
 if (run) {
   # Initialize a temporary GRASS project using the example data
   loc <- initGRASS(
@@ -176,6 +181,19 @@ if (run) {
   # Read the results back into R and plot
   u1 <- read_RAST(c("elev", "slope", "aspect"), return_format = "terra")
   plot(u1[["elev"]], col = terrain.colors(50))
+}
+
+# Restore the original GRASS session
+if (run) {
+  if (!inherits(loc, "try-error")) {
+    loc <- initGRASS(
+      gisBase = GRASS_INSTALLATION,
+      gisDbase = loc_existing$GISDBASE,
+      location = loc_existing$LOCATION_NAME,
+      mapset = loc_existing$MAPSET,
+      override = TRUE
+    )
+  }
 }
 }
 \seealso{


### PR DESCRIPTION
The pkgdown workflow now runs in a GRASS shell in the `nc_basic_spm_grass7` location. 

Additionally changes were also made to the `initGRASS` examples to check for the presence of an existing location and restoration of the location after the examples have run. This is because the `initGRASS` example uses a temporary location, which overrides the `nc_basic_spm_grass7` location.